### PR TITLE
Add AGENTS.md with guidelines for updating README.MD

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,37 @@
+# AGENTS.md
+
+## Purpose
+This repository is a curated list (`README.MD`) of deception-related resources. Future Codex runs should prioritize **accuracy over volume** and avoid speculative edits.
+
+## Rules for updating `README.MD`
+1. **Never fabricate details**
+   - Do not invent titles, dates, summaries, authors, venues, or claims.
+   - If a source page/PDF cannot be accessed well enough to verify facts, do **not** add or modify that entry.
+
+2. **Year must be verified, not inferred loosely**
+   - Confirm the year from the source itself (publication date, paper metadata, DOI page, arXiv record, conference page, etc.).
+   - Do not rely only on surrounding list context or assumptions.
+
+3. **Default placement rule: append to the end of the relevant subsection**
+   - Unless the user explicitly asks for reordering/sorting, add new bullets to the **end** of that subsection.
+   - Do not insert a new entry between existing items that share the same year unless explicitly asked to reorder.
+
+4. **Keep existing style consistent**
+   - Format: `- [Title](URL) (YEAR) - short description.` for paper-like entries.
+   - Use concise, factual descriptions based on verifiable source content.
+
+5. **Avoid silent quality regressions**
+   - Do not duplicate an existing link/resource.
+   - Ensure the resource goes in the correct section (`Articles`, `Research`, `Talks`, etc.).
+   - Preserve markdown structure and headings.
+
+## PR and commit title conventions
+- For paper additions, keep titles simple and consistent: `Add Paper - <short details on paper>`.
+- Avoid overly long or quirky PR/commit titles; prefer concise, descriptive wording.
+
+## Pre-commit checklist (required)
+- Verify each changed/added URL and title are real.
+- Verify each changed/added year is correct.
+- Confirm new bullets were appended (unless user requested different ordering).
+- Check for accidental duplicates.
+- Run: `git diff -- README.MD` and sanity-check every changed line.


### PR DESCRIPTION
### Motivation
- Introduce a repository-level policy file to guide future automated edits and human contributors to the curated deception resources list.
- Reduce risk of inaccurate or speculative changes to `README.MD` by documenting mandatory verification and formatting rules.

### Description
- Add `AGENTS.md` containing a Purpose section and explicit rules for updating `README.MD`, including prohibitions on fabrication and requirements to verify publication years from sources.
- Define a default placement rule to append new entries to the end of the relevant subsection unless reordering is explicitly requested.
- Establish a consistent formatting convention for entries (`- [Title](URL) (YEAR) - short description.`) and guidelines to avoid duplicates and preserve markdown structure.
- Add PR/commit title conventions and a pre-commit checklist that includes verifying URLs, years, placement, duplicates, and running `git diff -- README.MD`.

### Testing
- No automated tests were run for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b52cd7eaf0832585f8826e861bcc1e)