### PR TITLE
Add Paper - Deception and Detection (International Security 2026)

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -55,6 +55,7 @@ An awesome collection of articles, papers, conferences, guides, and tools relati
 - [HoneyTrap: Deceiving Large Language Model Attackers to Honeypot Traps with Resilient Multi-Agent Defense](https://arxiv.org/abs/2601.04034) (2026) - proposes a deceptive LLM defense framework with multi-agent coordination, plus a progressive jailbreak dataset and new metrics for measuring misdirection and attacker cost. 
 - [Measuring the Efficacy of Cyber Deception](https://www.techrxiv.org/doi/full/10.36227/techrxiv.176834017.70221537) (2026) - examines how to measure cyber deception effectiveness by reviewing existing evaluation approaches and proposing new metrics and frameworks to assess deceptive tactics in modern, AI-augmented threat environments.
 - [Q-Cowrie: Reinforcement Learning for Adaptive Honeypot Deception](https://link.springer.com/article/10.1007/s10207-026-01221-5) (2026) - presents “Q-Cowrie,” a reinforcement learning-enhanced Cowrie honeypot that models attacker decisions with an MDP and adapts responses during attacker interaction.
+- [Deception and Detection: Why Artificial Intelligence Empowers Cyber Defense over Offense](https://direct.mit.edu/isec/article/50/3/86/135683/Deception-and-Detection-Why-Artificial) (2026) - argues that AI automation benefits cyber defense more than offense, widening an offense-defense automation gap as stakes increase.
 
 ### Code Repositories
 - [Evaluating Deception and Moving Target Defense with Network Attack Simulation](https://github.com/dfki-in-sec/NASIM-MTD)


### PR DESCRIPTION
### Motivation
- Add the 2026 International Security article "Deception and Detection: Why Artificial Intelligence Empowers Cyber Defense over Offense" to the curated `Research -> Papers` list to capture a notable contribution on AI's differential utility for defense vs offense. 
- Attribute the suggestion/source in the PR to the submitted lead via `https://ctoatncsc.substack.com/` and follow repository rules to preserve accuracy and ordering.

### Description
- Appended a single formatted entry to the end of `Research -> Papers` in `README.MD`: `- [Deception and Detection: Why Artificial Intelligence Empowers Cyber Defense over Offense](https://direct.mit.edu/isec/article/50/3/86/135683/Deception-and-Detection-Why-Artificial) (2026) - argues that AI automation benefits cyber defense more than offense, widening an offense-defense automation gap as stakes increase.`
- Ensured formatting matches the repository convention and committed the change with message `Add Paper - Deception and Detection (International Security 2026)`, then created the PR body noting the `ctoatncsc.substack.com` lead.

### Testing
- Ran `rg -n "Deception and Detection: Why Artificial Intelligence Empowers Cyber Defense over Offense|Deception-and-Detection-Why-Artificial" README.MD` to confirm the new line appears and that check succeeded. 
- Ran `git diff -- README.MD` and `git commit` to sanity-check and record the change, which succeeded. 
- Attempted HTTP validation with `curl -I` against the provided article URL and `curl` against the DOI `https://doi.org/10.1162/ISEC.a.398`, but both network attempts returned HTTP 403 in this environment so live fetch verification was limited.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b52f0fbdac83258a8adbbb917200d1)