### PR TITLE
Add Article - Ars Technica canary trap leak report

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@
 - Resecurity on [synthetic data for cyber deception and honeypots](https://www.resecurity.com/es/blog/article/synthetic-data-a-new-frontier-for-cyber-deception-and-honeypots) (2025) explores synthetic data to improve honeypot realism.
 - Forescout on [a hacktivist attack targeting OT/ICS](https://www.forescout.com/blog/anatomy-of-a-hacktivist-attack-russian-aligned-group-targets-otics/) (2025) analyzes the incident, including honeypot use and defensive takeaways.
 - UpGuard on [preventing supply chain attacks with honeytokens](https://www.upguard.com/blog/prevent-supply-chain-attacks-with-honeytokens) (2025).
+- Ars Technica on [a Canadian election-list canary trap](https://arstechnica.com/tech-policy/2026/05/in-canada-a-canary-trap-springs-shut-and-ids-election-database-leak/) (2026) covers how salted entries identified the source of a voter database leak.
 
 ## Research
 


### PR DESCRIPTION
### Motivation
- Add a verified, recent news item to the `Articles` list documenting an Ars Technica report about a canary-trap that identified the source of a voter database leak so the curated list stays current.

### Description
- Appended one line to the end of the `Articles` subsection in `README.md`: `Ars Technica on [a Canadian election-list canary trap](https://arstechnica.com/tech-policy/2026/05/in-canada-a-canary-trap-springs-shut-and-ids-election-database-leak/) (2026) covers how salted entries identified the source of a voter database leak.`

### Testing
- Verified the source URL and publication year, confirmed the change with `git diff -- README.md`, committed the update with `git commit`, and inspected the file with `sed` and `nl`; all automated checks/commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f927ce61088325a7ecde1b1b2c84dd)