### PR TITLE
docs: add Wiz 2026 "Practical Package Security" entry to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@
 - Forescout on [a hacktivist attack targeting OT/ICS](https://www.forescout.com/blog/anatomy-of-a-hacktivist-attack-russian-aligned-group-targets-otics/) (2025) analyzes the incident, including honeypot use and defensive takeaways.
 - UpGuard on [preventing supply chain attacks with honeytokens](https://www.upguard.com/blog/prevent-supply-chain-attacks-with-honeytokens) (2025).
 - Ars Technica on [a Canadian election-list canary trap](https://arstechnica.com/tech-policy/2026/05/in-canada-a-canary-trap-springs-shut-and-ids-election-database-leak/) (2026) covers how salted entries identified the source of a voter database leak.
+- Wiz’s [Practical Package Security: The Unofficial Guide](https://www.wiz.io/blog/practical-package-security-the-unofficial-guide) (2026) highlights CI/CD honeytokens for high-signal detection, citing Grafana’s canary AWS key alert during a compromised GitHub Action incident.
 
 ## Research
 


### PR DESCRIPTION
### Motivation
- Keep the curated resources up to date by adding Wiz’s 2026 write-up on practical package security that highlights CI/CD honeytokens and references Grafana’s canary AWS key alert.

### Description
- Added a single article entry to `README.md` linking to Wiz’s "Practical Package Security: The Unofficial Guide" (2026) and noting its focus on CI/CD honeytokens.

### Testing
- No automated tests were run for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fa08aadaa48325be9364c65578034d)