### PR TITLE
Add 2026 paper 'Detecting Offensive Cyber Agents' to README research list

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@
 - [Measuring the Efficacy of Cyber Deception](https://www.techrxiv.org/doi/full/10.36227/techrxiv.176834017.70221537) (2026) - Examines how to measure cyber deception effectiveness by reviewing existing evaluation approaches and proposing new metrics and frameworks to assess deceptive tactics in modern, AI-augmented threat environments.
 - [Q-Cowrie: Reinforcement Learning for Adaptive Honeypot Deception](https://link.springer.com/article/10.1007/s10207-026-01221-5) (2026) - Presents “Q-Cowrie,” a reinforcement learning-enhanced Cowrie honeypot that models attacker decisions with an MDP and adapts responses during attacker interaction.
 - [Deception and Detection: Why Artificial Intelligence Empowers Cyber Defense over Offense](https://direct.mit.edu/isec/article/50/3/86/135683/Deception-and-Detection-Why-Artificial) (2026) - Argues that AI automation benefits cyber defense more than offense, widening an offense-defense automation gap as stakes increase.
+- [Detecting Offensive Cyber Agents: A Detection-in-Depth Approach](https://www.iaps.ai/research/detecting-offensive-cyber-agents) (2026) - Proposes detection-in-depth for offensive cyber agents, recommending agent honeypots to reveal autonomous attackers’ methods and urging existing honeypot operators to add agent-activity collection.
 
 ### Code Repositories
 


### PR DESCRIPTION
### Motivation
- Include a recent 2026 paper on detecting offensive cyber agents in the repository's research bibliography to keep the `README.md` papers list up to date with agent-focused deception guidance.

### Description
- Add a single new entry under the "Papers" section in `README.md` linking to "Detecting Offensive Cyber Agents: A Detection-in-Depth Approach" (2026).

### Testing
- No automated tests were applicable or run for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a184ecee99883259dc7dd0b12c4197e)