### PR TITLE
Add Black Hat USA 2026 talk on OpenAI–Hugging Face incident to README Talks

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@
 - [Turning The Tables: Using Cyber Deception To Hunt Phishers At Scale](https://www.youtube.com/watch?v=78qnM_ZzpNc) (2024) - BSides Exeter.
 - [Counter Deception: Defending Yourself in a World Full of Lies](https://www.youtube.com/watch?v=gHqDEMrqTjE) (2024) - DEF CON 32, Tom Cross and Greg Conti.
 - [Mirage: Cyber Deception Against Autonomous Cyber Attacks](https://www.youtube.com/watch?v=S0ioMe-g0vk) (2024) - Black Hat USA 2024, Ron Alford and Michael Kouremetis.
-- [The 'Breaking' News: The OpenAI–Hugging Face Incident](https://youtu.be/87DyyMV0kCY?t=2113) (2026) - Black Hat USA talk on the incident that calls for deploying honeytokens and deception to slow attacking AI agents.
+- [The 'Breaking' News: The OpenAI–Hugging Face Incident](https://youtu.be/87DyyMV0kCY?t=2113) (2026) - Black Hat USA talk on the incident that, at 35:13, calls for deploying honeytokens and deception to slow attacking AI agents.
 
 ## Podcasts
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@
 - [Turning The Tables: Using Cyber Deception To Hunt Phishers At Scale](https://www.youtube.com/watch?v=78qnM_ZzpNc) (2024) - BSides Exeter.
 - [Counter Deception: Defending Yourself in a World Full of Lies](https://www.youtube.com/watch?v=gHqDEMrqTjE) (2024) - DEF CON 32, Tom Cross and Greg Conti.
 - [Mirage: Cyber Deception Against Autonomous Cyber Attacks](https://www.youtube.com/watch?v=S0ioMe-g0vk) (2024) - Black Hat USA 2024, Ron Alford and Michael Kouremetis.
+- [The 'Breaking' News: The OpenAI–Hugging Face Incident](https://youtu.be/87DyyMV0kCY?t=2113) (2026) - Black Hat USA talk on the incident that calls for deploying honeytokens and deception to slow attacking AI agents.
 
 ## Podcasts
 


### PR DESCRIPTION
### Motivation
- Add a recent Black Hat USA 2026 talk that discusses the OpenAI–Hugging Face incident and recommends honeytokens and deception for slowing attacking AI agents to keep the resource list up to date.

### Description
- Added a new entry to the `Talks` section in `README.md` linking to "The 'Breaking' News: The OpenAI–Hugging Face Incident" YouTube segment with a timestamp and brief context.

### Testing
- No automated tests were applicable or run for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a778654e2648325a35e5731d0703bed)