### PR TITLE
Add Code Repository - Honeypot Auditor

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@
 - [Honeyquest](https://github.com/dynatrace-oss/honeyquest)
 - [Knocking on Admin’s Door: Protecting Critical Web Applications with Deception](https://github.com/BillyPragSec/pageknocking)
 - [SCANTRAP: Protecting Content Management Systems from Vulnerability Scanners with Cyber Deception and Obfuscation](https://github.com/dfki-in-sec/SCANTRAP)
+- [Honeypot Auditor](https://github.com/mziqudhd92/honeypot-auditor) - Multi-protocol CLI that fingerprints whether an authorized target behaves like a low-interaction honeypot using passive intel and non-destructive probes.
 
 ## Guides
 


### PR DESCRIPTION
## Summary
- Adds [Honeypot Auditor](https://github.com/mziqudhd92/honeypot-auditor) under Research → Code Repositories.

## Why it belongs
- On-topic as deception-aware detection tooling (not an individual honeypot): multi-protocol fingerprinting of low-interaction honeypot behavior on authorized targets.
- Appended at the bottom of the Code Repositories section per contributing guidelines.
- Format: `- [Name](link) - Description.` with verified stable GitHub URL (MIT, actively maintained).

## Checklist
- [x] Link verified
- [x] Not a duplicate
- [x] Appended to end of section
- [x] Neutral factual description